### PR TITLE
Feature/zps 293

### DIFF
--- a/.clocignore
+++ b/.clocignore
@@ -1,0 +1,1 @@
+ZenPacks/zenoss/PropertyMonitor/zenpacklib.py

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -31,5 +31,8 @@ Installing this ZenPack will add the following items to your Zenoss system.
 
 == Changes ==
 
+;1.1.1
+* Fix errors that can occur with components with certain characters in their IDs (ZPS-293)
+
 ;1.0.0
 * Initial release.

--- a/ZenPacks/zenoss/PropertyMonitor/services/PropertyMonitorService.py
+++ b/ZenPacks/zenoss/PropertyMonitor/services/PropertyMonitorService.py
@@ -124,7 +124,7 @@ class PropertyMonitorDataSourceConfig(pb.Copyable, pb.RemoteCopy):
         self.cycletime = datasource.getCycleTime(deviceOrComponent)
         self.datasourceId = datasource.id
         self.class_name = datasource.class_name
-        self.component_path = deviceOrComponent.getPrimaryUrlPath()
+        self.component_path = deviceOrComponent.getPrimaryId()
         self.property_name = datasource.property_name
 
         self.rrdConfig = {}


### PR DESCRIPTION
Use getPrimaryId() with getObjByPath()- the getPrimaryUrlPath() value is inappropriate for this usage.